### PR TITLE
GitHub Actionsテストの最適化 #116

### DIFF
--- a/.github/workflows/code-check-all-1.25.yml
+++ b/.github/workflows/code-check-all-1.25.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.25.8
+  GO_VERSION: 1.25.11
 
 jobs:
   prepare:

--- a/.github/workflows/code-check-all-1.26.yml
+++ b/.github/workflows/code-check-all-1.26.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.4
 
 jobs:
   prepare:

--- a/.github/workflows/code-check-all.yml
+++ b/.github/workflows/code-check-all.yml
@@ -5,22 +5,31 @@ on:
   workflow_call:
 
 jobs:
+  create-cache:
+    name: Create Cache
+    uses: ./.github/workflows/create-cache.yml
+
   code-check-1_22:
     name: Go 1.22
+    needs: create-cache
     uses: ./.github/workflows/code-check-all-1.22.yml
 
   code-check-1_23:
     name: Go 1.23
+    needs: create-cache
     uses: ./.github/workflows/code-check-all-1.23.yml
 
   code-check-1_24:
     name: Go 1.24
+    needs: create-cache
     uses: ./.github/workflows/code-check-all-1.24.yml
 
   code-check-1_25:
     name: Go 1.25
+    needs: create-cache
     uses: ./.github/workflows/code-check-all-1.25.yml
 
   code-check-1_26:
     name: Go 1.26
+    needs: create-cache
     uses: ./.github/workflows/code-check-all-1.26.yml

--- a/.github/workflows/code-check-darwin-amd64.yml
+++ b/.github/workflows/code-check-darwin-amd64.yml
@@ -11,17 +11,13 @@ on:
         type: string
 
 env:
+  GOOS: darwin
+  GOARCH: amd64
   TARGET: |
     {
-      "14": {
-        runner: "macos-14-large",
-      },
-      "15": {
-        runner: "macos-15-intel",
-      },
-      "26": {
-        runner: "macos-26-large",
-      },
+      "14": { "runner": "macos-14-large" },
+      "15": { "runner": "macos-15-intel" },
+      "26": { "runner": "macos-26-large" }
     }
 
 jobs:
@@ -41,8 +37,11 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/cache/restore@v6
         with:
-          go-version: ${{ inputs.go_version }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
+      - run: echo "${{ github.workspace }}/tmp/go/bin" >> $GITHUB_PATH
       - run: go vet ./...
       - run: go test ./...

--- a/.github/workflows/code-check-darwin-arm64.yml
+++ b/.github/workflows/code-check-darwin-arm64.yml
@@ -11,17 +11,13 @@ on:
         type: string
 
 env:
+  GOOS: darwin
+  GOARCH: arm64
   TARGET: |
     {
-      "14": {
-        runner: "macos-14",
-      },
-      "15": {
-        runner: "macos-15",
-      },
-      "26": {
-        runner: "macos-26",
-      },
+      "14": { "runner": "macos-14" },
+      "15": { "runner": "macos-15" },
+      "26": { "runner": "macos-26" }
     }
 
 jobs:
@@ -41,8 +37,11 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/cache/restore@v6
         with:
-          go-version: ${{ inputs.go_version }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
+      - run: echo "${{ github.workspace }}/tmp/go/bin" >> $GITHUB_PATH
       - run: go vet ./...
       - run: go test ./...

--- a/.github/workflows/code-check-dragonfly-amd64.yml
+++ b/.github/workflows/code-check-dragonfly-amd64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-first-class-1.22.yml
+++ b/.github/workflows/code-check-first-class-1.22.yml
@@ -57,7 +57,7 @@ jobs:
   linux-amd64:
     needs:
       - prepare
-    name: linux/386
+    name: linux/amd64
     uses: ./.github/workflows/code-check-linux-amd64.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}
@@ -103,7 +103,7 @@ jobs:
         version:
           - "2022"
           - "2025"
-    name: windows/arm64
+    name: windows/386
     uses: ./.github/workflows/code-check-windows-386.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}

--- a/.github/workflows/code-check-first-class-1.23.yml
+++ b/.github/workflows/code-check-first-class-1.23.yml
@@ -57,7 +57,7 @@ jobs:
   linux-amd64:
     needs:
       - prepare
-    name: linux/386
+    name: linux/amd64
     uses: ./.github/workflows/code-check-linux-amd64.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}
@@ -103,7 +103,7 @@ jobs:
         version:
           - "2022"
           - "2025"
-    name: windows/arm64
+    name: windows/386
     uses: ./.github/workflows/code-check-windows-386.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}

--- a/.github/workflows/code-check-first-class-1.24.yml
+++ b/.github/workflows/code-check-first-class-1.24.yml
@@ -57,7 +57,7 @@ jobs:
   linux-amd64:
     needs:
       - prepare
-    name: linux/386
+    name: linux/amd64
     uses: ./.github/workflows/code-check-linux-amd64.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}
@@ -103,7 +103,7 @@ jobs:
         version:
           - "2022"
           - "2025"
-    name: windows/arm64
+    name: windows/386
     uses: ./.github/workflows/code-check-windows-386.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}

--- a/.github/workflows/code-check-first-class-1.25.yml
+++ b/.github/workflows/code-check-first-class-1.25.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.25.8
+  GO_VERSION: 1.25.11
 
 jobs:
   prepare:
@@ -57,7 +57,7 @@ jobs:
   linux-amd64:
     needs:
       - prepare
-    name: linux/386
+    name: linux/amd64
     uses: ./.github/workflows/code-check-linux-amd64.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}
@@ -103,7 +103,7 @@ jobs:
         version:
           - "2022"
           - "2025"
-    name: windows/arm64
+    name: windows/386
     uses: ./.github/workflows/code-check-windows-386.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}

--- a/.github/workflows/code-check-first-class-1.26.yml
+++ b/.github/workflows/code-check-first-class-1.26.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.4
 
 jobs:
   prepare:
@@ -57,7 +57,7 @@ jobs:
   linux-amd64:
     needs:
       - prepare
-    name: linux/386
+    name: linux/amd64
     uses: ./.github/workflows/code-check-linux-amd64.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}
@@ -103,7 +103,7 @@ jobs:
         version:
           - "2022"
           - "2025"
-    name: windows/arm64
+    name: windows/386
     uses: ./.github/workflows/code-check-windows-386.yml
     with:
       go_version: ${{ needs.prepare.outputs.go_version }}

--- a/.github/workflows/code-check-first-class.yml
+++ b/.github/workflows/code-check-first-class.yml
@@ -4,22 +4,31 @@ on:
   workflow_call:
 
 jobs:
+  create-cache:
+    name: Create Cache
+    uses: ./.github/workflows/create-cache.yml
+
   code-check-1_22:
     name: Go 1.22
+    needs: create-cache
     uses: ./.github/workflows/code-check-first-class-1.22.yml
 
   code-check-1_23:
     name: Go 1.23
+    needs: create-cache
     uses: ./.github/workflows/code-check-first-class-1.23.yml
 
   code-check-1_24:
     name: Go 1.24
+    needs: create-cache
     uses: ./.github/workflows/code-check-first-class-1.24.yml
 
   code-check-1_25:
     name: Go 1.25
+    needs: create-cache
     uses: ./.github/workflows/code-check-first-class-1.25.yml
 
   code-check-1_26:
     name: Go 1.26
+    needs: create-cache
     uses: ./.github/workflows/code-check-first-class-1.26.yml

--- a/.github/workflows/code-check-freebsd-amd64.yml
+++ b/.github/workflows/code-check-freebsd-amd64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-freebsd-arm64.yml
+++ b/.github/workflows/code-check-freebsd-arm64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-linux-386.yml
+++ b/.github/workflows/code-check-linux-386.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOS: linux
-  GOARCH: 386
+  GOARCH: '386'
   PLATFORM: linux/386
 
 jobs:
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./... &&

--- a/.github/workflows/code-check-linux-amd64.yml
+++ b/.github/workflows/code-check-linux-amd64.yml
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./...

--- a/.github/workflows/code-check-linux-arm-v5.yml
+++ b/.github/workflows/code-check-linux-arm-v5.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOS: linux
-  GOARCH: arm
+  GOARCH: armv6l
   PLATFORM: linux/arm/v5
 
 jobs:
@@ -31,14 +31,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
-          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}v6l
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}v6l.tar.gz | tar -xzf - -C /tmp
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -46,12 +43,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               export GOARM=5 &&
               go vet ./... &&

--- a/.github/workflows/code-check-linux-arm-v6.yml
+++ b/.github/workflows/code-check-linux-arm-v6.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOS: linux
-  GOARCH: arm
+  GOARCH: armv6l
   PLATFORM: linux/arm/v6
 
 jobs:
@@ -31,14 +31,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
-          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}v6l
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}v6l.tar.gz | tar -xzf - -C /tmp
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -46,12 +43,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               export GOARM=6 &&
               go vet ./... &&

--- a/.github/workflows/code-check-linux-arm-v7.yml
+++ b/.github/workflows/code-check-linux-arm-v7.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOS: linux
-  GOARCH: arm
+  GOARCH: armv6l
   PLATFORM: linux/arm/v7
 
 jobs:
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
-          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}v6l
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}v6l.tar.gz | tar -xzf - -C /tmp
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               export GOARM=7 &&
               go vet ./... &&

--- a/.github/workflows/code-check-linux-arm64.yml
+++ b/.github/workflows/code-check-linux-arm64.yml
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./...

--- a/.github/workflows/code-check-linux-mips64le.yml
+++ b/.github/workflows/code-check-linux-mips64le.yml
@@ -25,20 +25,17 @@ jobs:
             name: CGO_ENABLED=0
             cgo: 0
           - image: mips64le/debian:latest
-            name: musl
+            name: GNU C Library
             cgo: 1
     name: linux/mips64le ${{ matrix.target.name }}(${{ matrix.target.image }})(${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -46,12 +43,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./...

--- a/.github/workflows/code-check-linux-ppc64le.yml
+++ b/.github/workflows/code-check-linux-ppc64le.yml
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./...

--- a/.github/workflows/code-check-linux-riscv64.yml
+++ b/.github/workflows/code-check-linux-riscv64.yml
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./...

--- a/.github/workflows/code-check-linux-s390x.yml
+++ b/.github/workflows/code-check-linux-s390x.yml
@@ -34,14 +34,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
-          path: /tmp/go
+          path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --location https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz | tar -xzf - -C /tmp
+          fail-on-cache-miss: true
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ env.PLATFORM }}
@@ -49,12 +46,11 @@ jobs:
           docker run \
             --rm \
             -v $(pwd):/workspace \
-            -v /tmp/go:/tmp/go \
             -w /workspace \
             --platform ${{ env.PLATFORM }} \
             ${{ matrix.target.image }} \
             sh -c "
-              export PATH=$PATH:/tmp/go/bin &&
+              export PATH=$PATH:/workspace/tmp/go/bin &&
               export CGO_ENABLED=${{ matrix.target.cgo }} &&
               go vet ./... &&
               go test ./...

--- a/.github/workflows/code-check-netbsd-amd64.yml
+++ b/.github/workflows/code-check-netbsd-amd64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-netbsd-arm64.yml
+++ b/.github/workflows/code-check-netbsd-arm64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-openbsd-amd64.yml
+++ b/.github/workflows/code-check-openbsd-amd64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-openbsd-arm64.yml
+++ b/.github/workflows/code-check-openbsd-arm64.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - id: cache
-        uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz https://go.dev/dl/go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          tar -xzf go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
-          rm go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}.tar.gz
+          fail-on-cache-miss: true
       - uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ env.VM_OS }}
@@ -44,8 +37,7 @@ jobs:
           shell: bash
       - shell: cpa.sh {0}
         run: |
-          mv ${{ github.workspace }}/tmp/go /tmp/go
-          export PATH=$PATH:/tmp/go/bin
+          export PATH=$PATH:${{ github.workspace }}/tmp/go/bin
           pkgs=$(go list -f "{{ .ImportPath }}" ./...)
           for pkg in ${pkgs}; do
             go vet ${pkg}

--- a/.github/workflows/code-check-windows-386.yml
+++ b/.github/workflows/code-check-windows-386.yml
@@ -11,14 +11,12 @@ on:
         type: string
 
 env:
+  GOOS: windows
+  GOARCH: '386'
   TARGET: |
     {
-      "2022": {
-        runner: "windows-2022",
-      },
-      "2025": {
-        runner: "windows-2025",
-      },
+      "2022": { "runner": "windows-2022" },
+      "2025": { "runner": "windows-2025" }
     }
 
 jobs:
@@ -38,9 +36,11 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/cache/restore@v6
         with:
-          go-version: ${{ inputs.go_version }}
-          architecture: '386'
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
+      - run: Add-Content $env:GITHUB_PATH "${{ github.workspace }}/tmp/go/bin"
       - run: go vet ./...
       - run: go test ./...

--- a/.github/workflows/code-check-windows-amd64.yml
+++ b/.github/workflows/code-check-windows-amd64.yml
@@ -11,14 +11,12 @@ on:
         type: string
 
 env:
+  GOOS: windows
+  GOARCH: amd64
   TARGET: |
     {
-      "2022": {
-        runner: "windows-2022",
-      },
-      "2025": {
-        runner: "windows-2025",
-      },
+      "2022": { "runner": "windows-2022" },
+      "2025": { "runner": "windows-2025" }
     }
 
 jobs:
@@ -38,8 +36,11 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/cache/restore@v6
         with:
-          go-version: ${{ inputs.go_version }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
+      - run: Add-Content $env:GITHUB_PATH "${{ github.workspace }}/tmp/go/bin"
       - run: go vet ./...
       - run: go test ./...

--- a/.github/workflows/code-check-windows-arm64.yml
+++ b/.github/workflows/code-check-windows-arm64.yml
@@ -11,11 +11,11 @@ on:
         type: string
 
 env:
+  GOOS: windows
+  GOARCH: arm64
   TARGET: |
     {
-      "11": {
-        runner: "windows-11-arm",
-      },
+      "11": { "runner": "windows-11-arm" }
     }
 
 jobs:
@@ -35,8 +35,11 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/cache/restore@v6
         with:
-          go-version: ${{ inputs.go_version }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ inputs.go_version }}.${{ env.GOOS }}-${{ env.GOARCH }}
+          fail-on-cache-miss: true
+      - run: Add-Content $env:GITHUB_PATH "${{ github.workspace }}/tmp/go/bin"
       - run: go vet ./...
       - run: go test ./...

--- a/.github/workflows/create-cache-1.22.yml
+++ b/.github/workflows/create-cache-1.22.yml
@@ -7,61 +7,35 @@ env:
   GO_VERSION: 1.22.12
 
 jobs:
-  create-cache-runner:
+  create-cache-darwin:
     strategy:
       fail-fast: false
       matrix:
-          target:
-            # setup-go-macOS-x64
-            - runner: macos-15-intel
-              name: darwin/amd64
-            # setup-go-macOS-arm64
-            - runner: macos-26
-              name: darwin/arm64
-            # setup-go-Linux-x64-ubuntu22
-            - runner: ubuntu-22.04
-              name: linux/amd64(Ubuntu 22.04)
-            # setup-go-Linux-x64-ubuntu24
-            - runner: ubuntu-24.04
-              name: linux/amd64(Ubuntu 24.04)
-            # setup-go-Linux-arm64-ubuntu22
-            - runner: ubuntu-22.04-arm
-              name: linux/arm64(Ubuntu 22.04)
-            # setup-go-Linux-arm64-ubuntu24
-            - runner: ubuntu-24.04-arm
-              name: linux/arm64(Ubuntu 24.04)
-            # setup-go-Windows-x64
-            - runner: windows-2025
-              name: windows/amd64
-            # setup-go-Windows-arm64
-            - runner: windows-11-arm
-              name: windows/arm64
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
+        target:
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    name: Create Cache macOS(${{ matrix.target.os }}/${{ matrix.target.arch }})
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - id: cache
+        uses: actions/cache/restore@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-  create-cache-runner-architecture:
-    strategy:
-      fail-fast: false
-      matrix:
-          target:
-            - runner: windows-2025
-              name: windows/386(Windows Server 2025)
-              architecture: '386'
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-          architecture: ${{ matrix.target.architecture }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
 
-  create-cache-binary:
+  create-cache-linux:
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +48,10 @@ jobs:
             arch: arm64
           - os: linux
             arch: '386'
+          - os: linux
+            arch: 'amd64'
+          - os: linux
+            arch: arm64
           - os: linux
             arch: armv6l
           # - os: linux
@@ -92,17 +70,57 @@ jobs:
             arch: amd64
           - os: openbsd
             arch: arm64
-    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    name: Create Cache Linux(${{ matrix.target.os }}/${{ matrix.target.arch }})
     runs-on: ubuntu-latest
     steps:
       - id: cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
       - if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
-          tar -xzf go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+
+  create-cache-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: windows
+            arch: '386'
+          - os: windows
+            arch: 'amd64'
+          - os: windows
+            arch: 'arm64'
+    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: windows-latest
+    steps:
+      - id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          New-Item -ItemType Directory -Path "tmp"
+          Invoke-WebRequest -Uri "https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -OutFile "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip"
+          Expand-Archive -Path "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -DestinationPath "tmp"
+          Remove-Item -Recurse "tmp/go/api"
+          Remove-Item -Recurse "tmp/go/doc"
+          Remove-Item -Recurse "tmp/go/misc"
+          Remove-Item -Recurse "tmp/go/test"
+          Get-ChildItem -Path "tmp/go/src" -Filter "*_test.go" -Recurse | Remove-Item
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}

--- a/.github/workflows/create-cache-1.23.yml
+++ b/.github/workflows/create-cache-1.23.yml
@@ -7,61 +7,35 @@ env:
   GO_VERSION: 1.23.12
 
 jobs:
-  create-cache-runner:
+  create-cache-darwin:
     strategy:
       fail-fast: false
       matrix:
-          target:
-            # setup-go-macOS-x64
-            - runner: macos-15-intel
-              name: darwin/amd64
-            # setup-go-macOS-arm64
-            - runner: macos-26
-              name: darwin/arm64
-            # setup-go-Linux-x64-ubuntu22
-            - runner: ubuntu-22.04
-              name: linux/amd64(Ubuntu 22.04)
-            # setup-go-Linux-x64-ubuntu24
-            - runner: ubuntu-24.04
-              name: linux/amd64(Ubuntu 24.04)
-            # setup-go-Linux-arm64-ubuntu22
-            - runner: ubuntu-22.04-arm
-              name: linux/arm64(Ubuntu 22.04)
-            # setup-go-Linux-arm64-ubuntu24
-            - runner: ubuntu-24.04-arm
-              name: linux/arm64(Ubuntu 24.04)
-            # setup-go-Windows-x64
-            - runner: windows-2025
-              name: windows/amd64
-            # setup-go-Windows-arm64
-            - runner: windows-11-arm
-              name: windows/arm64
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
+        target:
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    name: Create Cache macOS(${{ matrix.target.os }}/${{ matrix.target.arch }})
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - id: cache
+        uses: actions/cache/restore@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-  create-cache-runner-architecture:
-    strategy:
-      fail-fast: false
-      matrix:
-          target:
-            - runner: windows-2025
-              name: windows/386(Windows Server 2025)
-              architecture: '386'
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-          architecture: ${{ matrix.target.architecture }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
 
-  create-cache-binary:
+  create-cache-linux:
     strategy:
       fail-fast: false
       matrix:
@@ -75,9 +49,13 @@ jobs:
           - os: linux
             arch: '386'
           - os: linux
-            arch: armv6l
+            arch: 'amd64'
           - os: linux
-            arch: mips64le
+            arch: arm64
+          - os: linux
+            arch: armv6l
+          # - os: linux
+          #   arch: mips64le
           - os: linux
             arch: ppc64le
           - os: linux
@@ -92,17 +70,57 @@ jobs:
             arch: amd64
           - os: openbsd
             arch: arm64
-    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    name: Create Cache Linux(${{ matrix.target.os }}/${{ matrix.target.arch }})
     runs-on: ubuntu-latest
     steps:
       - id: cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
       - if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
-          tar -xzf go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+
+  create-cache-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: windows
+            arch: '386'
+          - os: windows
+            arch: 'amd64'
+          - os: windows
+            arch: 'arm64'
+    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: windows-latest
+    steps:
+      - id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          New-Item -ItemType Directory -Path "tmp"
+          Invoke-WebRequest -Uri "https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -OutFile "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip"
+          Expand-Archive -Path "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -DestinationPath "tmp"
+          Remove-Item -Recurse "tmp/go/api"
+          Remove-Item -Recurse "tmp/go/doc"
+          Remove-Item -Recurse "tmp/go/misc"
+          Remove-Item -Recurse "tmp/go/test"
+          Get-ChildItem -Path "tmp/go/src" -Filter "*_test.go" -Recurse | Remove-Item
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}

--- a/.github/workflows/create-cache-1.24.yml
+++ b/.github/workflows/create-cache-1.24.yml
@@ -7,61 +7,35 @@ env:
   GO_VERSION: 1.24.13
 
 jobs:
-  create-cache-runner:
+  create-cache-darwin:
     strategy:
       fail-fast: false
       matrix:
-          target:
-            # setup-go-macOS-x64
-            - runner: macos-15-intel
-              name: darwin/amd64
-            # setup-go-macOS-arm64
-            - runner: macos-26
-              name: darwin/arm64
-            # setup-go-Linux-x64-ubuntu22
-            - runner: ubuntu-22.04
-              name: linux/amd64(Ubuntu 22.04)
-            # setup-go-Linux-x64-ubuntu24
-            - runner: ubuntu-24.04
-              name: linux/amd64(Ubuntu 24.04)
-            # setup-go-Linux-arm64-ubuntu22
-            - runner: ubuntu-22.04-arm
-              name: linux/arm64(Ubuntu 22.04)
-            # setup-go-Linux-arm64-ubuntu24
-            - runner: ubuntu-24.04-arm
-              name: linux/arm64(Ubuntu 24.04)
-            # setup-go-Windows-x64
-            - runner: windows-2025
-              name: windows/amd64
-            # setup-go-Windows-arm64
-            - runner: windows-11-arm
-              name: windows/arm64
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
+        target:
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    name: Create Cache macOS(${{ matrix.target.os }}/${{ matrix.target.arch }})
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - id: cache
+        uses: actions/cache/restore@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-  create-cache-runner-architecture:
-    strategy:
-      fail-fast: false
-      matrix:
-          target:
-            - runner: windows-2025
-              name: windows/386(Windows Server 2025)
-              architecture: '386'
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-          architecture: ${{ matrix.target.architecture }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
 
-  create-cache-binary:
+  create-cache-linux:
     strategy:
       fail-fast: false
       matrix:
@@ -75,9 +49,13 @@ jobs:
           - os: linux
             arch: '386'
           - os: linux
-            arch: armv6l
+            arch: 'amd64'
           - os: linux
-            arch: mips64le
+            arch: arm64
+          - os: linux
+            arch: armv6l
+          # - os: linux
+          #   arch: mips64le
           - os: linux
             arch: ppc64le
           - os: linux
@@ -92,17 +70,57 @@ jobs:
             arch: amd64
           - os: openbsd
             arch: arm64
-    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    name: Create Cache Linux(${{ matrix.target.os }}/${{ matrix.target.arch }})
     runs-on: ubuntu-latest
     steps:
       - id: cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
       - if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
-          tar -xzf go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+
+  create-cache-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: windows
+            arch: '386'
+          - os: windows
+            arch: 'amd64'
+          - os: windows
+            arch: 'arm64'
+    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: windows-latest
+    steps:
+      - id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          New-Item -ItemType Directory -Path "tmp"
+          Invoke-WebRequest -Uri "https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -OutFile "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip"
+          Expand-Archive -Path "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -DestinationPath "tmp"
+          Remove-Item -Recurse "tmp/go/api"
+          Remove-Item -Recurse "tmp/go/doc"
+          Remove-Item -Recurse "tmp/go/misc"
+          Remove-Item -Recurse "tmp/go/test"
+          Get-ChildItem -Path "tmp/go/src" -Filter "*_test.go" -Recurse | Remove-Item
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}

--- a/.github/workflows/create-cache-1.25.yml
+++ b/.github/workflows/create-cache-1.25.yml
@@ -4,64 +4,38 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.25.8
+  GO_VERSION: 1.25.11
 
 jobs:
-  create-cache-runner:
+  create-cache-darwin:
     strategy:
       fail-fast: false
       matrix:
-          target:
-            # setup-go-macOS-x64
-            - runner: macos-15-intel
-              name: darwin/amd64
-            # setup-go-macOS-arm64
-            - runner: macos-26
-              name: darwin/arm64
-            # setup-go-Linux-x64-ubuntu22
-            - runner: ubuntu-22.04
-              name: linux/amd64(Ubuntu 22.04)
-            # setup-go-Linux-x64-ubuntu24
-            - runner: ubuntu-24.04
-              name: linux/amd64(Ubuntu 24.04)
-            # setup-go-Linux-arm64-ubuntu22
-            - runner: ubuntu-22.04-arm
-              name: linux/arm64(Ubuntu 22.04)
-            # setup-go-Linux-arm64-ubuntu24
-            - runner: ubuntu-24.04-arm
-              name: linux/arm64(Ubuntu 24.04)
-            # setup-go-Windows-x64
-            - runner: windows-2025
-              name: windows/amd64
-            # setup-go-Windows-arm64
-            - runner: windows-11-arm
-              name: windows/arm64
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
+        target:
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    name: Create Cache macOS(${{ matrix.target.os }}/${{ matrix.target.arch }})
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - id: cache
+        uses: actions/cache/restore@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-  create-cache-runner-architecture:
-    strategy:
-      fail-fast: false
-      matrix:
-          target:
-            - runner: windows-2025
-              name: windows/386(Windows Server 2025)
-              architecture: '386'
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-          architecture: ${{ matrix.target.architecture }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
 
-  create-cache-binary:
+  create-cache-linux:
     strategy:
       fail-fast: false
       matrix:
@@ -75,9 +49,13 @@ jobs:
           - os: linux
             arch: '386'
           - os: linux
-            arch: armv6l
+            arch: 'amd64'
           - os: linux
-            arch: mips64le
+            arch: arm64
+          - os: linux
+            arch: armv6l
+          # - os: linux
+          #   arch: mips64le
           - os: linux
             arch: ppc64le
           - os: linux
@@ -92,17 +70,57 @@ jobs:
             arch: amd64
           - os: openbsd
             arch: arm64
-    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    name: Create Cache Linux(${{ matrix.target.os }}/${{ matrix.target.arch }})
     runs-on: ubuntu-latest
     steps:
       - id: cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
       - if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
-          tar -xzf go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+
+  create-cache-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: windows
+            arch: '386'
+          - os: windows
+            arch: 'amd64'
+          - os: windows
+            arch: 'arm64'
+    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: windows-latest
+    steps:
+      - id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          New-Item -ItemType Directory -Path "tmp"
+          Invoke-WebRequest -Uri "https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -OutFile "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip"
+          Expand-Archive -Path "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -DestinationPath "tmp"
+          Remove-Item -Recurse "tmp/go/api"
+          Remove-Item -Recurse "tmp/go/doc"
+          Remove-Item -Recurse "tmp/go/misc"
+          Remove-Item -Recurse "tmp/go/test"
+          Get-ChildItem -Path "tmp/go/src" -Filter "*_test.go" -Recurse | Remove-Item
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}

--- a/.github/workflows/create-cache-1.26.yml
+++ b/.github/workflows/create-cache-1.26.yml
@@ -4,64 +4,38 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.4
 
 jobs:
-  create-cache-runner:
+  create-cache-darwin:
     strategy:
       fail-fast: false
       matrix:
-          target:
-            # setup-go-macOS-x64
-            - runner: macos-15-intel
-              name: darwin/amd64
-            # setup-go-macOS-arm64
-            - runner: macos-26
-              name: darwin/arm64
-            # setup-go-Linux-x64-ubuntu22
-            - runner: ubuntu-22.04
-              name: linux/amd64(Ubuntu 22.04)
-            # setup-go-Linux-x64-ubuntu24
-            - runner: ubuntu-24.04
-              name: linux/amd64(Ubuntu 24.04)
-            # setup-go-Linux-arm64-ubuntu22
-            - runner: ubuntu-22.04-arm
-              name: linux/arm64(Ubuntu 22.04)
-            # setup-go-Linux-arm64-ubuntu24
-            - runner: ubuntu-24.04-arm
-              name: linux/arm64(Ubuntu 24.04)
-            # setup-go-Windows-x64
-            - runner: windows-2025
-              name: windows/amd64
-            # setup-go-Windows-arm64
-            - runner: windows-11-arm
-              name: windows/arm64
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
+        target:
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    name: Create Cache macOS(${{ matrix.target.os }}/${{ matrix.target.arch }})
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - id: cache
+        uses: actions/cache/restore@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-  create-cache-runner-architecture:
-    strategy:
-      fail-fast: false
-      matrix:
-          target:
-            - runner: windows-2025
-              name: windows/386(Windows Server 2025)
-              architecture: '386'
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-          architecture: ${{ matrix.target.architecture }}
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
 
-  create-cache-binary:
+  create-cache-linux:
     strategy:
       fail-fast: false
       matrix:
@@ -75,9 +49,13 @@ jobs:
           - os: linux
             arch: '386'
           - os: linux
-            arch: armv6l
+            arch: 'amd64'
           - os: linux
-            arch: mips64le
+            arch: arm64
+          - os: linux
+            arch: armv6l
+          # - os: linux
+          #   arch: mips64le
           - os: linux
             arch: ppc64le
           - os: linux
@@ -92,17 +70,57 @@ jobs:
             arch: amd64
           - os: openbsd
             arch: arm64
-    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    name: Create Cache Linux(${{ matrix.target.os }}/${{ matrix.target.arch }})
     runs-on: ubuntu-latest
     steps:
       - id: cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/tmp/go
           key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
       - if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          mkdir tmp
-          cd tmp
-          curl --location --output go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
-          tar -xzf go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          curl --location --create-dirs --output tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz
+          tar -xzf tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.tar.gz --directory=tmp --exclude='go/api' --exclude='go/doc' --exclude='go/misc' --exclude='go/src/*_test.go' --exclude='go/test'
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+
+  create-cache-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: windows
+            arch: '386'
+          - os: windows
+            arch: 'amd64'
+          - os: windows
+            arch: 'arm64'
+    name: ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: windows-latest
+    steps:
+      - id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}
+          lookup-only: true
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          New-Item -ItemType Directory -Path "tmp"
+          Invoke-WebRequest -Uri "https://go.dev/dl/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -OutFile "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip"
+          Expand-Archive -Path "tmp/go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}.zip" -DestinationPath "tmp"
+          Remove-Item -Recurse "tmp/go/api"
+          Remove-Item -Recurse "tmp/go/doc"
+          Remove-Item -Recurse "tmp/go/misc"
+          Remove-Item -Recurse "tmp/go/test"
+          Get-ChildItem -Path "tmp/go/src" -Filter "*_test.go" -Recurse | Remove-Item
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/tmp/go
+          key: go${{ env.GO_VERSION }}.${{ matrix.target.os }}-${{ matrix.target.arch }}

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -5,4 +5,49 @@
 
 ## 開発方針
 
-- Pure Go
+- CGOを使用しない
+- 比較演算子は次の物のみを使用する
+  - `==`
+  - `!=`
+  - `<`
+  - `<=`
+
+## テスト対象
+
+|GOOS/GOARCH|OS Version|Go Version|
+|-|-|-|
+|darwin/amd64|14, 15, 26|1.22 or later|
+|darwin/arm64|14, 15, 26|1.22 or later|
+|dragonfly/amd64|6.4.2|1.22 or later|
+|freebsd/amd64|12.2, 12.4, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 14.0, 14.1, 14.2, 14.3, 14.4, 15.0, 15.1|1.22 or later|
+|freebsd/arm64|12.4, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 14.0, 14.1, 14.2, 14.3, 14.4, 15.0, 15.1|1.22 or later|
+|linux/386(CGO_ENABLED=0)||1.22 or later|
+|linux/386(GNU C Library)||1.22 or later|
+|linux/386(musl)||1.22 or later|
+|linux/arm v5(CGO_ENABLED=0)||1.22 or later|
+|linux/arm v5(GNU C Library)||1.22 or later|
+|linux/arm v6(CGO_ENABLED=0)||1.22 or later|
+|linux/arm v6(musl)||1.22 or later|
+|linux/arm v7(CGO_ENABLED=0)||1.22 or later|
+|linux/arm v7(GNU C Library)||1.22 or later|
+|linux/arm v7(musl)||1.22 or later|
+|linux/arm64(CGO_ENABLED=0)||1.22 or later|
+|linux/arm64(GNU C Library)||1.22 or later|
+|linux/arm64(musl)||1.22 or later|
+|linux/mips64le(CGO_ENABLED=0)||1.23 or later|
+|linux/mips64le(GNU C Library)||1.23 or later|
+|linux/ppc64le(CGO_ENABLED=0)||1.22 or later|
+|linux/ppc64le(GNU C Library)||1.22 or later|
+|linux/riscv64(CGO_ENABLED=0)||1.22 or later|
+|linux/riscv64(GNU C Library)||1.22 or later|
+|linux/riscv64(musl)||1.22 or later|
+|linux/s390x(CGO_ENABLED=0)||1.22 or later|
+|linux/s390x(GNU C Library)||1.22 or later|
+|linux/s390x(musl)||1.22 or later|
+|netbsd/amd64|9.2, 9.3, 9.4, 10.0, 10.1|1.22 or later|
+|netbsd/arm64|10.0, 10.1|1.22 or later|
+|openbsd/amd64|6.8, 6.9, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9|1.22 or later|
+|openbsd/arm64|6.9, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9|1.22 or later|
+|windows/386|Windows Server 2022, Windows Server 2025|1.22 or later|
+|windows/amd64|Windows Server 2022, Windows Server 2025|1.22 or later|
+|windows/arm64|Windows 11|1.22 or later|


### PR DESCRIPTION
ci: update Go 1.25.11
ci: update Go 1.26.4
change: キャッシュを生成してからテストを実行するようにした
change: actions/setup-goを使用せずにActions Cacheを使用するようにした

close #116 